### PR TITLE
Pr validation improvements

### DIFF
--- a/lib/rubee/extensions/validatable.rb
+++ b/lib/rubee/extensions/validatable.rb
@@ -34,7 +34,7 @@ module Rubee
       def required(error_message = nil)
         value = @instance.send(@attribute)
 
-        error_hash = assemble_error_hash(error_message, :required)
+        error_hash = assemble_error_hash(error_message, :required, attribute: @attribute)
         if value.nil? || (value.respond_to?(:empty?) && value.empty?)
           @state.add_error(@attribute, error_hash)
         end
@@ -94,7 +94,7 @@ module Rubee
       def default_message(type, **options)
         {
           condition: "condition is not met",
-          required: "attribute is required",
+          required: "attribute '#{options[:attribute]}' is required",
           type: "attribute must be #{options[:class]}",
         }[type]
       end
@@ -131,7 +131,13 @@ module Rubee
 
       def run_validations
         @__validation_state = State.new
-        self.class&.validation_block&.call(self)
+        if (block = self.class.validation_block)
+          instance_exec(&block)
+        end
+      end
+
+      def subject
+        @__validation_state.instance
       end
 
       def attribute(name)

--- a/lib/tests/models/account_model_test.rb
+++ b/lib/tests/models/account_model_test.rb
@@ -18,9 +18,8 @@ describe 'Account model' do
 
     describe '#validate_before_persist' do
       it 'rasies error if account is not valid' do
-        Account.validate do |account|
-          account
-            .required(:addres, required: "address is required")
+        Account.validate do
+          required(:addres, required: "address is required")
             .type(String, type: "address must be string")
         end
         Account.validate_before_persist!


### PR DESCRIPTION
2.1.1
**Changes**
* Syntax improvement for the validation feature
* No need to pass the instance in the block, it is available through self
* There is a possibility to pass a string/hash or nothing to the validation method
* First method changed to attribute

```
class Foo
  include Rubee::Validatable

  attr_accessor :name, :age

  def initialize(name, age)
    @name = name
    @age = age
  end

  validate do
    attribute(:name).required.type(String).condition(->{ name.length > 2 })

    attribute(:age)
      .required('Age is a manadatory field')
      .type(Integer, error_message: 'Must be an integerRRRRRRrrr!')
      .condition(->{ age > 18 }, fancy_error: 'You must be at least 18 years old, dude!')
  end
end
```
```
class User < Rubee::SequelObject
  attr_accessor :id, :email, :password, :created, :updated

  validate_before_persist! # This will validate and raise error in case invalid before saving to DB
  validate do
    attribute(:email).required
      .condition(
        ->{ email.match?(/\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i) }, error: 'Wrong email format'
      )
  end
end
```
