### PR TITLE
PR-auth-model-agnostic

### DIFF
--- a/lib/db/create_clients.rb
+++ b/lib/db/create_clients.rb
@@ -1,0 +1,15 @@
+class CreateClients
+  def call
+    return if Rubee::SequelObject::DB.tables.include?(:clients)
+
+    Rubee::SequelObject::DB.create_table(:clients) do
+      primary_key(:id)
+      String(:name)
+      String(:digest_password)
+      index(:name)
+      # timestamps
+      datetime(:created)
+      datetime(:updated)
+    end
+  end
+end

--- a/lib/rubee/controllers/extensions/auth_tokenable.rb
+++ b/lib/rubee/controllers/extensions/auth_tokenable.rb
@@ -3,7 +3,7 @@ require 'date'
 
 module Rubee
   module AuthTokenable
-    KEY = "secret#{Date.today}".freeze unless defined?(KEY) # Feel free to cusomtize it
+    KEY ="secret#{ENV['JWT_KEY']}#{Date.today}".freeze unless defined?(KEY) # Feel free to cusomtize it
     EXPIRE = 3600 unless defined?(EXPIRE)
 
     def self.included(base)
@@ -28,7 +28,7 @@ module Rubee
       end
 
       def authentificated_user(user_model: ::User, login: :email, password: :password)
-        if params[:email] && params[:password]
+        if params[login] && params[password]
           query_params = { login => params[login], password => params[password] }
           @authentificated_user ||= user_model.where(query_params).first
         elsif @request.cookies['jwt'] && valid_token?

--- a/lib/tests/controllers/auth_tokenable_test.rb
+++ b/lib/tests/controllers/auth_tokenable_test.rb
@@ -26,6 +26,30 @@ class TestController < Rubee::BaseController
   end
 end
 
+class TesttwoController < Rubee::BaseController
+  include(Rubee::AuthTokenable)
+  auth_methods(:show)
+  def show
+    response_with(type: :json, object: { ok: :ok })
+  end
+
+  # POST /testtwo/login (login logic)
+  def login
+    if authentificate!(user_model: Client, login: :name, password: :digest_password)
+      response_with(type: :json, object: { ok: :ok }, headers: @token_header)
+    else
+      @error = "Wrong email or password"
+      response_with(type: :json, object: { error: 'user unauthenticated' }, status: :unauthenticated)
+    end
+  end
+
+  # POST /testtwo/logout (logout logic)
+  def logout
+    unauthentificate!(user_model: Client, login: :name, password: :digest_password)
+    response_with(type: :json, object: { ok: 'logged out' }, headers: @zeroed_token_header)
+  end
+end
+
 class AuthTokenableTest < Minitest::Test
   include Rack::Test::Methods
 
@@ -39,9 +63,12 @@ class AuthTokenableTest < Minitest::Test
       route.post('/test/login', to: 'test#login')
       route.post('/test/logout', to: 'test#logout')
       route.get('/test/show', to: 'test#show')
+      route.post('/testtwo/login', to: 'testtwo#login')
+      route.post('/testtwo/logout', to: 'testtwo#logout')
+      route.get('/testtwo/show', to: 'testtwo#show')
     end
     User.create(email: '9oU8S@example.com', password: '123456')
-
+    Client.create(name: '9oU8S@example.com', digest_password: '123456')
   end
 
   def test_test_controller_included_auth_tokenable
@@ -58,7 +85,17 @@ class AuthTokenableTest < Minitest::Test
     assert_equal(last_response.status, 200)
   end
 
-  def test_test_controller_included_auth_tokenable_authenticated_custom_model
+  def test_test_controller_included_auth_tokenable_unauthenticated_custom_model
+    get('/testtwo/show')
 
+    assert_equal(last_response.status, 401)
+  end
+
+  def test_test_controller_included_auth_tokenable_authenticated_custom_model
+    post('/testtwo/login', { name: '9oU8S@example.com', digest_password: '123456' })
+    rack_mock_session.cookie_jar["jwt"] = last_response.cookies["jwt"].value.last
+    get('/testtwo/show')
+
+    assert_equal(last_response.status, 200)
   end
 end

--- a/lib/tests/example_models/client.rb
+++ b/lib/tests/example_models/client.rb
@@ -1,0 +1,3 @@
+class Client < Rubee::SequelObject
+  attr_accessor :id, :name, :digest_password, :created, :updated
+end


### PR DESCRIPTION
**Changes ver. 2.2.0**
- added params to authentificate! and unauthentificate! methods, so the auth model can be set explicetely in the methods by introducing target model agnostic behaviour.
- added JWT_KEY to be a salt for the JWT encode decode logic.